### PR TITLE
Prevent running migration in transaction when specified

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,9 @@
   },
   "scripts": {
     "lint": "eslint src",
-    "test-unit": "ava",
-    "test": "npm run lint && npm run test-unit",
+    "test-integration": "ava",
+    "test-unit": "ava src/**/__unit__/**/*.js",
+    "test": "npm run test-unit && npm run lint && npm run test-integration",
     "preversion": "npm test",
     "prepush": "npm test"
   },
@@ -43,6 +44,8 @@
     "@mft/eslint-config-momentumft": "^2.1.0",
     "ava": "^0.17.0",
     "eslint": "^3.9.1",
-    "husky": "^0.11.9"
+    "husky": "^0.11.9",
+    "sinon": "^1.17.0",
+    "sinon-bluebird": "^3.1.0"
   }
 }

--- a/src/__unit__/run-migration/index.js
+++ b/src/__unit__/run-migration/index.js
@@ -1,0 +1,124 @@
+const test = require("ava")
+const sinon = require("sinon")
+require("sinon-bluebird")
+
+const bluebird = require("bluebird")
+
+const runMigration = require("../../run-migration")
+
+const readFile = bluebird.promisify(require("fs").readFile)
+
+let normalSqlFile
+let noTransactionSqlFile
+
+test.before(() => {
+  return bluebird.all([
+    readFile(__dirname + "/normal.sql", "utf8").then(contents => {
+      normalSqlFile = contents
+    }),
+
+    readFile(__dirname + "/no-transaction.sql", "utf8").then(contents => {
+      noTransactionSqlFile = contents
+    }),
+  ])
+})
+
+function buildMigration(sql) {
+  return {
+    id: "id",
+    name: "name",
+    sql,
+    hash: "hash",
+  }
+}
+
+test("runs a simple migration", t => {
+  const queryAsync = sinon.stub().resolves()
+  const run = runMigration({queryAsync})
+
+  const migration = buildMigration(normalSqlFile)
+
+  return run(migration).then(() => {
+    t.is(queryAsync.callCount, 4)
+    t.is(
+      queryAsync.firstCall.args[0],
+      "START TRANSACTION",
+      "should begin a transaction"
+    )
+
+    t.is(
+      queryAsync.secondCall.args[0],
+      migration.sql,
+      "should execute the migration"
+    )
+
+    t.deepEqual(
+      queryAsync.thirdCall.args[0].values,
+      [migration.id, migration.name, migration.hash],
+      "should record the running of the migration in the database"
+    )
+
+    t.is(
+      queryAsync.lastCall.args[0],
+      "COMMIT",
+      "should complete the transaction"
+    )
+  })
+})
+
+test("rolls back when there is an error inside a transactiony migration", t => {
+  const queryAsync = sinon.stub().rejects(new Error("There was a problem"))
+  const run = runMigration({queryAsync})
+
+  const migration = buildMigration(normalSqlFile)
+  t.plan(2)
+
+  return run(migration).catch(e => {
+    t.is(queryAsync.lastCall.args[0], "ROLLBACK", "should perform a rollback")
+    t.true(
+      e.message.indexOf("There was a problem") >= 0,
+      "should throw an error"
+    )
+  })
+})
+
+test("does not run the migration in a transaction when instructed", t => {
+  const queryAsync = sinon.stub().resolves()
+  const run = runMigration({queryAsync})
+
+  const migration = buildMigration(noTransactionSqlFile)
+
+  return run(migration).then(() => {
+    t.is(queryAsync.callCount, 2)
+
+    t.is(
+      queryAsync.firstCall.args[0],
+      migration.sql,
+      "should run the migration"
+    )
+
+    t.deepEqual(
+      queryAsync.secondCall.args[0].values,
+      [migration.id, migration.name, migration.hash],
+      "should record the running of the migration in the database"
+    )
+  })
+})
+
+test(
+  "does not roll back when there is an error inside a transactiony migration",
+  t => {
+    const queryAsync = sinon.stub().rejects(new Error("There was a problem"))
+    const run = runMigration({queryAsync})
+
+    const migration = buildMigration(noTransactionSqlFile)
+
+    return run(migration).catch(e => {
+      sinon.assert.neverCalledWith(queryAsync, "ROLLBACK")
+      t.true(
+        e.message.indexOf("There was a problem") >= 0,
+        "should throw an error"
+      )
+    })
+  }
+)

--- a/src/__unit__/run-migration/no-transaction.sql
+++ b/src/__unit__/run-migration/no-transaction.sql
@@ -1,0 +1,2 @@
+-- postgres-migrations disable-transaction
+CREATE INDEX CONCURRENTLY thingy_idx on eggs (color);

--- a/src/__unit__/run-migration/normal.sql
+++ b/src/__unit__/run-migration/normal.sql
@@ -1,0 +1,3 @@
+-- pointless comment
+SELECT * from eggs
+  WHERE color = 2

--- a/src/run-migration.js
+++ b/src/run-migration.js
@@ -1,0 +1,47 @@
+const bluebird = require("bluebird")
+const SQL = require("sql-template-strings")
+const dedent = require("dedent-js")
+
+const noop = () => {}
+
+module.exports = client => migration => {
+  const inTransaction = migration.sql
+    .split("\n")[0]
+    .indexOf("-- postgres-migrations disable-transaction") === -1
+
+  const begin = inTransaction
+    ? client.queryAsync.bind(client, "START TRANSACTION")
+    : noop
+
+  const end = inTransaction
+    ? client.queryAsync.bind(client, "COMMIT")
+    : noop
+
+  const cleanup = inTransaction
+    ? client.queryAsync.bind(client, "ROLLBACK")
+    : noop
+
+  return bluebird
+    .resolve()
+    .then(begin)
+    .then(() => client.queryAsync(migration.sql))
+    .then(() => {
+      return client.queryAsync(
+        SQL`
+        INSERT INTO migrations (id, name, hash)
+          VALUES (${migration.id}, ${migration.name}, ${migration.hash})
+      `
+      )
+    })
+    .then(end)
+    .catch(err => {
+      return bluebird.resolve().tap(cleanup).then(() => {
+        throw new Error(
+          dedent`
+            An error occurred running '${migration.name}'. Rolled back this migration.
+            No further migrations were run.
+            Reason: ${err.message}`
+        )
+      })
+    })
+}


### PR DESCRIPTION
Certain commands cannot be run inside a transaction, such as adding
indexes concurrently. Therefore, we allow the migration to request being
run without a transaction being started.